### PR TITLE
docker-compose.ymlを静的ファイルとして配信しない

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ exclude:
   - package.json
   - package-lock.json
   - node_modules
+  - docker-compose.yml
 keep_files:             ["css"]
 
 # Collections


### PR DESCRIPTION
close #7 
_siteにdocker-compose.ymlが出来てしまうので、
_config.ymlのexcludeにdocker-compose.ymlを追加する。